### PR TITLE
Adding staging and devel branches

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -2,5 +2,20 @@
   "projects": {
     "staging": "mst-ka",
     "default": "mst-ka"
+  },
+  "targets": {
+    "mst-ka": {
+      "hosting": {
+        "prod": [
+          "mst-ka"
+        ],
+        "staging": [
+          "staging-mst-ka"
+        ],
+        "devel": [
+          "devel-mst-ka"
+        ]
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,17 @@ already familiar with Git & Terminal commands.
   1. Create a development branch of the repository
   2. In your new branch make whatever changes you wish.
   3. Test your changes with multiple window sizes to ensure mobile compatibility.
-  4. Submit a PR with the changes.
+  4. Create a PR with the changes.
+  5. Run 
+
+  ```
+  firebase deploy --only hosting:devel
+  ```
+
+  6. Send a message in the group chat that your changes 
+     are live on [devel-mst-ka.firebaseapp.com](devel-mst-ka.firebaseapp.com)
+
+For more info on different deploy targets, check out [this article](https://firebase.google.com/docs/cli/targets)
 
 #### Branch Naming
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
-  "hosting": {
+  "hosting": [{
+    "target": "prod",
     "public": "active",
     "cleanUrls": true,
     "ignore": [
@@ -14,6 +15,38 @@
       "Jared Hanisch <jared.hanisch@gmail.com>"
     ]
   },
+  {
+    "target": "staging",
+    "public": "active",
+    "cleanUrls": true,
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "public/",
+      "active/img/originals"
+    ],
+    "contributors": [
+      "Joe Studer <joe.studer.18@gmail.com>",
+      "Jared Hanisch <jared.hanisch@gmail.com>"
+    ]
+  },
+  {
+    "target": "devel",
+    "public": "active",
+    "cleanUrls": true,
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "public/",
+      "active/img/originals"
+    ],
+    "contributors": [
+      "Joe Studer <joe.studer.18@gmail.com>",
+      "Jared Hanisch <jared.hanisch@gmail.com>"
+    ]
+  }],
   "emulators": {
     "functions": {
       "port": 5001


### PR DESCRIPTION
These should make our lives a little easier when we launch to the main website. Devel will be a better place to test rough changes/share info quickly w/ reviewers and to test on our mobile devices in the wild.

Staging will be used to test before pushing to prod. We'll probably want to hone out a better process (like a 2-key launch code kinda system - especially for bigger changes), but in the mean time just using staging, testing on multiple devices, then sending should be good.