### PR TITLE
Suppress and Add Fields to Alumni Newsletter Sign-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /.pnp
 .pnp.js
 
-#firebase
+# firebase
 .firebase/
 
 # testing
@@ -14,6 +14,9 @@
 # build directory
 /out
 .next/
+
+# editor
+.vscode/
 
 # misc
 .DS_Store

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -35,7 +35,7 @@ function Layout(props) {
         {props.children}
       </Container>
       <Footer />
-      {router.pathname !== "/apply" ? (
+      {router.pathname !== "/apply" && (
         <Fab
           variant="extended"
           color="primary"
@@ -45,7 +45,7 @@ function Layout(props) {
           <ContactPageIcon sx={{ marginRight: ".3rem" }} />
           Apply for Membership
         </Fab>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/components/Subpages/Alumni/NewsletterSignUp.js
+++ b/components/Subpages/Alumni/NewsletterSignUp.js
@@ -20,6 +20,13 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CloseIcon from "@mui/icons-material/Close";
 
 const validationSchema = yup.object({
+  firstName: yup.string().required("Required"),
+  lastName: yup.string().required("Required"),
+  pledgeClass: yup
+    .number()
+    .typeError("Please enter your pledge class year")
+    .positive("Pledge class must be a positive year")
+    .required("Required"),
   email: yup.string().email("Please enter a valid email").required("Required"),
 });
 
@@ -45,14 +52,13 @@ function NewsletterSignup() {
   };
 
   // We do not want to modify the 'showSignup' state and save that
-  // value in local storage if we are just hiding the form (Clicking '
+  // value in local storage if we are just hiding the form (Clicking
   // the 'X'). We only want to prevent the form from showing up upon
-  //revisits if the user has already submitted their email. 
-  const [tempHideSignup, setTempHideSignup] = useState(true)
+  // revisits if the user has already submitted their email.
+  const [tempHideSignup, setTempHideSignup] = useState(true);
   const handleTempHideSignup = () => {
     setTempHideSignup(false);
-  }
-
+  };
 
   const [openSuccessSnackbar, setOpenSuccessSnackbar] = useState(false);
   const handleCloseSuccessSnackbar = () => {
@@ -66,6 +72,9 @@ function NewsletterSignup() {
 
   const formik = useFormik({
     initialValues: {
+      firstName: "",
+      lastName: "",
+      pledgeClass: "",
       email: "",
     },
     validationSchema: validationSchema,
@@ -85,10 +94,10 @@ function NewsletterSignup() {
            *
            * This is done to allow us to loop through to see if the submitted
            * value by the user already exists in the database. If it doesn't we
-           * add it, if it does we do NOT add it and notify the user.
+           * add it, if it does, we do NOT add it, and then notify the user.
            */
           let emailEntryExists = false;
-          if(data != undefined || data != null){
+          if (data != undefined || data != null) {
             for (let uniqueKey of Object.values(data)) {
               if (uniqueKey.email === values.email) {
                 emailEntryExists = true;
@@ -97,9 +106,12 @@ function NewsletterSignup() {
               }
             }
           }
-          
+
           if (!emailEntryExists) {
             push(ref(database, "newsletterEmailSignUp/"), {
+              firstName: values.firstName,
+              lastName: values.lastName,
+              pledgeClass: values.pledgeClass,
               email: values.email,
             }).then(() => {
               //Upon success
@@ -157,6 +169,42 @@ function NewsletterSignup() {
               Sign up to make sure you never miss out on a new issue of The BAAA
               Journal!
             </Typography>
+            <TextField
+              id="firstName"
+              fullWidth
+              variant="standard"
+              label="First Name"
+              {...formik.getFieldProps("firstName")}
+              error={
+                formik.touched.firstName && Boolean(formik.errors.firstName)
+              }
+              helperText={formik.touched.firstName && formik.errors.firstName}
+              sx={{ marginTop: ".5rem" }}
+            />
+            <TextField
+              fullWidth
+              id="lastName"
+              variant="standard"
+              label="Last Name"
+              {...formik.getFieldProps("lastName")}
+              error={formik.touched.lastName && Boolean(formik.errors.lastName)}
+              helperText={formik.touched.lastName && formik.errors.lastName}
+              sx={{ marginTop: ".5rem" }}
+            />
+            <TextField
+              fullWidth
+              id="pledgeClass"
+              variant="standard"
+              label="Pledge Class (ex: 1997)"
+              {...formik.getFieldProps("pledgeClass")}
+              error={
+                formik.touched.pledgeClass && Boolean(formik.errors.pledgeClass)
+              }
+              helperText={
+                formik.touched.pledgeClass && formik.errors.pledgeClass
+              }
+              sx={{ marginTop: ".5rem" }}
+            />
             <TextField
               fullWidth
               id="email"

--- a/components/Subpages/Alumni/NewsletterSignUp.js
+++ b/components/Subpages/Alumni/NewsletterSignUp.js
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import { useFormik } from "formik";
 import * as yup from "yup";
-import { onValue, push, ref } from "firebase/database";
+import { push, ref } from "firebase/database";
 import database from "../../../firebase-init.js";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CloseIcon from "@mui/icons-material/Close";
@@ -63,11 +63,6 @@ function NewsletterSignup() {
   const [openSuccessSnackbar, setOpenSuccessSnackbar] = useState(false);
   const handleCloseSuccessSnackbar = () => {
     setOpenSuccessSnackbar(false);
-  };
-
-  const [openWarnSnackbar, setOpenWarnSnackbar] = useState(false);
-  const handleCloseWarnSnackbar = () => {
-    setOpenWarnSnackbar(false);
   };
 
   const formik = useFormik({
@@ -198,18 +193,6 @@ function NewsletterSignup() {
       >
         <Alert variant="filled" severity="success">
           Thank you, your email has been added to our distribution list!
-        </Alert>
-      </Snackbar>
-      <Snackbar
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        open={openWarnSnackbar}
-        autoHideDuration={6000}
-        onClose={handleCloseWarnSnackbar}
-        // Push snackbar above the 'Apply For Membership' Button
-        sx={{ bottom: { mobile: "4.5rem" } }}
-      >
-        <Alert variant="filled" severity="warning">
-          You have already added your email to our distribution list!
         </Alert>
       </Snackbar>
     </form>

--- a/components/Subpages/Alumni/NewsletterSignUp.js
+++ b/components/Subpages/Alumni/NewsletterSignUp.js
@@ -79,56 +79,17 @@ function NewsletterSignup() {
     },
     validationSchema: validationSchema,
     onSubmit: (values, { resetForm }) => {
-      const newsletterEmailRef = ref(database, "newsletterEmailSignUp/");
-      // Query existing email entries in the database
-      onValue(
-        newsletterEmailRef,
-        (snapshot) => {
-          const data = snapshot.val();
-          /*
-           * Convert newsletterEmailSignUp object (which contains objects
-           * of objects differentiated by their unique keys) to an array of
-           * objects of the form:
-           *
-           *    [ { email: "user1@email.com" }, { email: "user2@email.com" }, ...]
-           *
-           * This is done to allow us to loop through to see if the submitted
-           * value by the user already exists in the database. If it doesn't we
-           * add it, if it does, we do NOT add it, and then notify the user.
-           */
-          let emailEntryExists = false;
-          if (data != undefined || data != null) {
-            for (let uniqueKey of Object.values(data)) {
-              if (uniqueKey.email === values.email) {
-                emailEntryExists = true;
-                setOpenWarnSnackbar(true);
-                break;
-              }
-            }
-          }
+      push(ref(database, "newsletterEmailSignUp/"), {
+        firstName: values.firstName,
+        lastName: values.lastName,
+        pledgeClass: values.pledgeClass,
+        email: values.email,
+      }).then(() => {
+        //Upon success
+        setOpenSuccessSnackbar(true);
+        handleCloseSignup();
+      });
 
-          if (!emailEntryExists) {
-            push(ref(database, "newsletterEmailSignUp/"), {
-              firstName: values.firstName,
-              lastName: values.lastName,
-              pledgeClass: values.pledgeClass,
-              email: values.email,
-            }).then(() => {
-              //Upon success
-              setOpenSuccessSnackbar(true);
-              handleCloseSignup();
-            });
-          }
-        },
-        {
-          // We want to only run onValue()'s callback once to retrieve
-          // the emails that already exist in the database and compare
-          // the email being submitted. If this option was not set then
-          // the onValue() callback would fire again when a new user
-          // email is pushed.
-          onlyOnce: true,
-        }
-      );
       resetForm();
     },
   });

--- a/pages/alumni/index.js
+++ b/pages/alumni/index.js
@@ -1,7 +1,7 @@
 import { Container, Grid, Typography } from "@mui/material";
 import Banner from "../../components/Layout/Banner/Banner";
 import Newsletter from "../../components/Subpages/Alumni/Newsletter";
-import NewsletterSignUp from "../../components/Subpages/Alumni/NewsletterSignUp";
+import NewsletterSignup from "../../components/Subpages/Alumni/NewsletterSignUp";
 
 const newsletters = [
   {
@@ -83,7 +83,7 @@ function Alumni() {
           ))}
         </Grid>
       </Container>
-      <NewsletterSignUp/>
+      <NewsletterSignup/>
     </div>
   );
 }


### PR DESCRIPTION
This PR closes #172

If a user submits their contact information to receive the newsletter we don't want to spam them to fill it out every time they visit and or refresh the page. 

To solve this, a boolean value will be set in local storage to determine if the user has previously submitted their information. The drawbacks to this are that if the user uses a different browser or clears their bowser data, the signup will be shown again. To counter that though, we will be querying the database to see if the user's email they are trying to submit already exists. If it does we will just warn them that we already have their email. 

In addition to the above changes, we are now requesting First Name, Last Name, and Pledge Class to determine if the entries are legitimate. Only question is: do we want to make filling out the Pledge class field mandatory, in case for example: someone's wife wants to get the newsletter?

Let me know what you think!