### PR TITLE
Bump Node version for Cloud Functions v2

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -16,8 +16,8 @@
         "firebase-functions-test": "^0.2.0"
       },
       "engines": {
-        "node": "20",
-        "npm": ">=9.0.0"
+        "node": "22",
+        "npm": ">=9.0.0 <12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,8 +10,8 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20",
-    "npm": ">=9.0.0"
+    "node": "22",
+    "npm": ">=9.0.0 <12.0.0"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Ran into an issue when deploying and found out I needed to update the node version for Cloud Functions v2 to be >=22 and restrict the npm version to be <12.